### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/assets/stylesheets/items/index.css
+++ b/app/assets/stylesheets/items/index.css
@@ -9,7 +9,7 @@ a {
 /* 画面上部の「人生を変えるフリマアプリ」帯部分 */
 .title-contents {
   width: 100vw;
-  background-image: image-url('furima-header01.png');
+  background-image: url('furima-header01.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;
@@ -124,7 +124,7 @@ a {
 /* 画面中央の「会員数日本一位」帯部分*/
 .ad-contents {
   width: 100vw;
-  background-image: image-url('furima-header02.png');
+  background-image: url('furima-header02.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;

--- a/app/assets/stylesheets/shared/footer.css
+++ b/app/assets/stylesheets/shared/footer.css
@@ -3,7 +3,7 @@
 
 .ad-footer-contents {
   width: 100vw;
-  background-image: image-url('furima-footer.png');
+  background-image: url('furima-footer.png');
   background-size: cover;
   background-repeat: no-repeat;
   background-position: top center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,6 +18,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :redirect_to_sign_in, except: [:index]
+  before_action :redirect_to_sign_in, except: [:index, :show]
 
   def index
     @items = Item.order("created_at DESC")

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
 
         <% @items.each do |item| %>
           <li class='list'>
-            <%= link_to "#" do %>
+            <%= link_to item_path(item) do %>
               <div class='item-img-content'>
                 <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,0 +1,110 @@
+<%= render "shared/header" %>
+
+<%# 商品の概要 %>
+<div class="item-show">
+  <div class="item-box">
+    <h2 class="name">
+      <%= @item.name %>
+    </h2>
+    <div class="item-img-content">
+      <%= image_tag @item.image ,class:"item-box-img" %>
+      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# <div class="sold-out">
+      <%#  <span>Sold Out!!</span>
+      <%# </div>
+      <%# //商品が売れている場合は、sold outを表示しましょう %>
+    </div>
+    <div class="item-price-box">
+      <span class="item-price">
+        ¥ <%= @item.price %>
+      </span>
+      <span class="item-postage">
+        <%= @item.fee_status.name %>
+      </span>
+    </div>
+
+    <%# ログインユーザーが出品者本人の場合に編集・削除ボタンを表示 %> 
+    <% if user_signed_in? && current_user.id == @item.user.id %>
+      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      <p class="or-text">or</p>
+      <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%# ログインユーザーが出品者本人ではない場合に購入ボタンを表示 %>
+    <% elsif user_signed_in? %>
+      <%# 商品が売れていない場合はこちらを表示しましょう %>
+      <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+      <%# //商品が売れていない場合はこちらを表示しましょう %>    
+    <%# 非ログイン時には何も表示しない %>
+    <% end %>
+
+    <div class="item-explain-box">
+      <span><%= @item.info %></span>
+    </div>
+    <table class="detail-table">
+      <tbody>
+        <tr>
+          <th class="detail-item">出品者</th>
+          <td class="detail-value"><%= @item.user.nickname %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">カテゴリー</th>
+          <td class="detail-value"><%= @item.category.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">商品の状態</th>
+          <td class="detail-value"><%= @item.item_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">配送料の負担</th>
+          <td class="detail-value"><%= @item.fee_status.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送元の地域</th>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
+        </tr>
+        <tr>
+          <th class="detail-item">発送日の目安</th>
+          <td class="detail-value"><%= @item.delivery_schedule.name %></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="option">
+      <div class="favorite-btn">
+        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
+        <span>お気に入り 0</span>
+      </div>
+      <div class="report-btn">
+        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
+        <span>不適切な商品の通報</span>
+      </div>
+    </div>
+  </div>
+  <%# /商品の概要 %>
+
+  <div class="comment-box">
+    <form>
+      <textarea class="comment-text"></textarea>
+      <p class="comment-warn">
+        相手のことを考え丁寧なコメントを心がけましょう。
+        <br>
+        不快な言葉遣いなどは利用制限や退会処分となることがあります。
+      </p>
+      <button type="submit" class="comment-btn">
+        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
+        <span>コメントする<span>
+      </button>
+    </form>
+  </div>
+  <div class="links">
+    <a href="#" class="change-item-btn">
+      ＜ 前の商品
+    </a>
+    <a href="#" class="change-item-btn">
+      後ろの商品 ＞
+    </a>
+  </div>
+
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+
+</div>
+
+<%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
 
 end


### PR DESCRIPTION
# What
- 商品詳細画面へのリンク設定
- 商品詳細画面の表示内容設定
( 商品購入機能が未実装のため、売却済みの場合の表示については未実装です )

# Why
商品詳細表示機能の実装のため

# 動作確認のキャプチャ (GyazoのURL)
- ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移 : 
　　前半：https://gyazo.com/76805c995169894f03b19335a9d271db
　　後半：https://gyazo.com/4886b2dc3bcd3e7713aeca5cb559aa6a
- ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移 : 
　　前半：https://gyazo.com/9cad2cdd4d6d8bc015a0020da7b829ad
　　後半：https://gyazo.com/28fd28299a993ad75d2d72e4d3e4d079
- ログアウト状態で商品詳細ページへ遷移 : 
　　前半：https://gyazo.com/a69da2aa6b690d430937c495fd4e2449
　　後半：https://gyazo.com/14ed6351ae0523810c9a947e874662f8